### PR TITLE
PairMembers を実装

### DIFF
--- a/modules/member/src/domain/pair/models/pair-members.spec.ts
+++ b/modules/member/src/domain/pair/models/pair-members.spec.ts
@@ -1,0 +1,76 @@
+import { PairMembers } from '@domain/pair/models/pair-members'
+import { ParticipantId } from '@domain/participant/models'
+import { Faker } from '@domain/utils'
+import { DomainException } from '@kobe/common/domain'
+
+describe('PairMembers', () => {
+  test('参加者 ID を配列で渡すと作成できる', () => {
+    const memberIds = Faker.participantIdArray(2)
+
+    const actualPairMembers = new PairMembers(memberIds)
+
+    const serialized = actualPairMembers.serialize()
+    expect(serialized.length).toBe(2)
+    expect(serialized).toEqual(expect.arrayContaining([memberIds[0].value, memberIds[1].value]))
+  })
+
+  test('２人未満のペアは作成できない', () => {
+    const memberIds = Faker.participantIdArray(1)
+    const act = () => new PairMembers(memberIds)
+
+    expect(act).toThrow(DomainException)
+    expect(act).toThrow(`メンバー数は最低 2 人必要です`)
+  })
+
+  test('４人以上のペアは作成できない', () => {
+    const memberIds = Faker.participantIdArray(4)
+    const act = () => new PairMembers(memberIds)
+
+    expect(act).toThrow(DomainException)
+    expect(act).toThrow(`メンバー数は最大 3 人までです`)
+  })
+
+  test('重複して参加することはできない', () => {
+    const participantId = new ParticipantId()
+
+    const act = () => new PairMembers([participantId, participantId])
+
+    expect(act).toThrow(DomainException)
+    expect(act).toThrow(`重複した参加者がいます`)
+  })
+
+  test('メンバーを追加できる', () => {
+    const memberIds = Faker.participantIdArray(2)
+    const pairMembers = new PairMembers(memberIds)
+    const newMemberId = new ParticipantId()
+
+    const actualPairMembers = pairMembers.add(newMemberId)
+
+    const serialized = actualPairMembers.serialize()
+    expect(serialized.length).toBe(3)
+    expect(serialized).toEqual(expect.arrayContaining([newMemberId.value]))
+  })
+
+  test('メンバーを削除できる', () => {
+    const memberIds = Faker.participantIdArray(3)
+    const pairMembers = new PairMembers(memberIds)
+    const leavingMemberId = memberIds[0]
+
+    const actualPairMembers = pairMembers.remove(leavingMemberId)
+
+    const serialized = actualPairMembers.serialize()
+    expect(serialized.length).toBe(2)
+    expect(serialized).not.toEqual(expect.arrayContaining([leavingMemberId.value]))
+  })
+
+  test('存在しないメンバーは削除できない', () => {
+    const memberIds = Faker.participantIdArray(3)
+    const pairMembers = new PairMembers(memberIds)
+    const nonMemberId = new ParticipantId()
+
+    const act = () => pairMembers.remove(nonMemberId)
+
+    expect(act).toThrow(DomainException)
+    expect(act).toThrow(`${nonMemberId.value} は在籍していません`)
+  })
+})

--- a/modules/member/src/domain/pair/models/pair-members.ts
+++ b/modules/member/src/domain/pair/models/pair-members.ts
@@ -1,0 +1,52 @@
+import { ParticipantId } from '@domain/participant/models'
+import { DomainException } from '@kobe/common/domain'
+import { ICollection } from '@kobe/common/domain/type/collection.interface'
+
+export class PairMembers implements ICollection<ParticipantId> {
+  readonly type = 'PairMembers' as const
+
+  private static MIN_MEMBERS_COUNT = 2
+  private static MAX_MEMBERS_COUNT = 3
+
+  constructor(private readonly memberIds: ParticipantId[]) {
+    this.validate()
+  }
+
+  private validate() {
+    if (this.count < PairMembers.MIN_MEMBERS_COUNT) {
+      throw new DomainException(`メンバー数は最低 ${PairMembers.MIN_MEMBERS_COUNT} 人必要です`)
+    }
+
+    if (this.count > PairMembers.MAX_MEMBERS_COUNT) {
+      throw new DomainException(`メンバー数は最大 ${PairMembers.MAX_MEMBERS_COUNT} 人までです`)
+    }
+
+    if (this.count !== new Set(this.memberIds).size) {
+      throw new DomainException('重複した参加者がいます')
+    }
+  }
+
+  add(memberId: ParticipantId) {
+    return new PairMembers([...this.memberIds, memberId])
+  }
+
+  remove(memberId: ParticipantId) {
+    if (!this.includes(memberId)) {
+      throw new DomainException(`${memberId.value} は在籍していません`)
+    }
+
+    return new PairMembers(this.memberIds.filter((id) => id.value !== memberId.value))
+  }
+
+  private includes(memberId: ParticipantId) {
+    return this.memberIds.some((id) => id.value === memberId.value)
+  }
+
+  private get count() {
+    return this.memberIds.length
+  }
+
+  serialize() {
+    return this.memberIds.map((member) => member.value)
+  }
+}

--- a/modules/member/src/domain/team/models/team-members.spec.ts
+++ b/modules/member/src/domain/team/models/team-members.spec.ts
@@ -5,57 +5,65 @@ import { DomainException } from '@kobe/common/domain/error'
 
 describe('TeamMembers', () => {
   test('参加者 ID を配列で渡すと作成できる', () => {
-    const teamMembers = TeamMembers.create([new ParticipantId(), new ParticipantId(), new ParticipantId()])
+    const memberIds = Faker.participantIdArray(3)
 
-    expect(teamMembers.count).toBe(3)
+    const actualTeamMembers = new TeamMembers(memberIds)
+
+    const serialized = actualTeamMembers.serialize()
+    expect(serialized.length).toBe(3)
+    expect(serialized).toEqual(expect.arrayContaining([memberIds[0].value, memberIds[1].value, memberIds[2].value]))
   })
 
   test('３人未満のチームは作成できない', () => {
-    const act = () => TeamMembers.create([new ParticipantId(), new ParticipantId()])
+    const memberIds = Faker.participantIdArray(2)
+
+    const act = () => new TeamMembers(memberIds)
 
     expect(act).toThrow(DomainException)
     expect(act).toThrow(`メンバー数は最低 3 人必要です`)
   })
 
-  test('add に 参加者 ID を渡すとメンバーを追加できる', () => {
+  test('重複して参加することはできない', () => {
+    const participantId = new ParticipantId()
+
+    const act = () => new TeamMembers([participantId, participantId, new ParticipantId()])
+
+    expect(act).toThrow(DomainException)
+    expect(act).toThrow(`重複した参加者がいます`)
+  })
+
+  test('メンバーを追加できる', () => {
     const memberIds = Faker.participantIdArray(3)
-    const teamMembers = TeamMembers.create(memberIds)
+    const teamMembers = new TeamMembers(memberIds)
     const newMemberIds = new ParticipantId()
 
     const actualTeamMembers = teamMembers.add(newMemberIds)
 
-    expect(actualTeamMembers.count).toBe(4)
+    const serialized = actualTeamMembers.serialize()
+    expect(serialized.length).toBe(4)
+    expect(serialized).toEqual(expect.arrayContaining([newMemberIds.value]))
   })
 
-  test('remove に 参加者 ID を渡すとメンバーを削除できる', () => {
+  test('メンバーを削除できる', () => {
     const memberIds = Faker.participantIdArray(4)
-    const teamMembers = TeamMembers.create(memberIds)
+    const teamMembers = new TeamMembers(memberIds)
     const leavingMemberId = memberIds[0]
 
     const actualTeamMembers = teamMembers.remove(leavingMemberId)
 
-    expect(actualTeamMembers.count).toBe(3)
+    const serialized = actualTeamMembers.serialize()
+    expect(serialized.length).toBe(3)
+    expect(serialized).not.toEqual(expect.arrayContaining([leavingMemberId.value]))
   })
 
-  test('２人以下になる remove はできない', () => {
+  test('存在しないメンバーは削除できない', () => {
     const memberIds = Faker.participantIdArray(3)
-    const teamMembers = TeamMembers.create(memberIds)
-    const leavingMemberId = memberIds[0]
-
-    const act = () => teamMembers.remove(leavingMemberId)
-
-    expect(act).toThrow(DomainException)
-    expect(act).toThrow('メンバー数が 3 人を下回ってしまいます')
-  })
-
-  test('存在しない参加者は remove できない', () => {
-    const memberIds = Faker.participantIdArray(3)
-    const teamMembers = TeamMembers.create(memberIds)
+    const teamMembers = new TeamMembers(memberIds)
     const nonMemberId = new ParticipantId()
 
     const act = () => teamMembers.remove(nonMemberId)
 
     expect(act).toThrow(DomainException)
-    expect(act).toThrow(`${nonMemberId.value} は在籍していないです`)
+    expect(act).toThrow(`${nonMemberId.value} は在籍していません`)
   })
 })

--- a/modules/member/src/domain/utils/faker.ts
+++ b/modules/member/src/domain/utils/faker.ts
@@ -14,7 +14,7 @@ export const participantIdArray = (count: number) => {
 }
 
 export const teamMembers = (count = 3) => {
-  return TeamMembers.create(participantIdArray(count))
+  return new TeamMembers(participantIdArray(count))
 }
 
 export const team = () => {


### PR DESCRIPTION
* PairMembers 実装
* それに合わせて TeamMembers のリファクタリング
  * バリデーションロジックはコンストラクターに集約
  * それによって不要になった例外処理を削除
  * create メソッドも不要になったのでデフォルトコンストラクタを使うように変更